### PR TITLE
All events in a single row side-by-side

### DIFF
--- a/pyvocz/templates/index.html
+++ b/pyvocz/templates/index.html
@@ -66,43 +66,45 @@
 
     <div id="events">
         <h2>{{ tr('Kdy a kde?', 'When & Where?') }}</h2>
-        <div>
+        <div class="row">
             {% for event in featured_events %}
-            <div class="event">
-                <h3>
-                    <a href="{{ url_for('series', series_slug=event.series.slug) }}">
-                        <img src="{{ url_for('static', filename='coatofarms/'+event.series.home_city_slug+'.svg') }}" width="50">
-                        {{event.series.name}}
-                    </a>
-                </h3>
-                <div>
-                    {% if event.date == today %}
-                        {% if g.lang_code == 'cs' %}
-                            <em>Dnes</em>
-                            v <time datetime="{{event.date}}">{{event.start_time.hour}}:{{'%02d' | format(event.start_time.minute)}}</time> je
-                        {% else %}
-                            <em>Today</em>
-                            at <time datetime="{{event.date}}">{{event.start_time.hour}}:{{'%02d' | format(event.start_time.minute)}}</time>:
-                        {% endif %}
-                    {% else %}
-                        {{ tr('', 'On') }}
-                        <em><time datetime="{{event.date}}">{{event.date | shortday}}</time></em>
-                        {% if event.date < today %}
-                            {{ tr('bylo', 'was') }}
-                        {% else %}
-                            {{ tr('bude', 'will be') }}
-                        {% endif %}
-                    {% endif %}
-                    <em class="title">{{ event | event_link }}</em>
+                <div class="col-md-4 col">
+                    <div class="event">
+                        <h3>
+                            <a href="{{ url_for('series', series_slug=event.series.slug) }}">
+                                <img src="{{ url_for('static', filename='coatofarms/'+event.series.home_city_slug+'.svg') }}" width="50">
+                                {{event.series.name}}
+                            </a>
+                        </h3>
+                        <div>
+                            {% if event.date == today %}
+                                {% if g.lang_code == 'cs' %}
+                                    <em>Dnes</em>
+                                    v <time datetime="{{event.date}}">{{event.start_time.hour}}:{{'%02d' | format(event.start_time.minute)}}</time> je
+                                {% else %}
+                                    <em>Today</em>
+                                    at <time datetime="{{event.date}}">{{event.start_time.hour}}:{{'%02d' | format(event.start_time.minute)}}</time>:
+                                {% endif %}
+                            {% else %}
+                                {{ tr('', 'On') }}
+                                <em><time datetime="{{event.date}}">{{event.date | shortday}}</time></em>
+                                {% if event.date < today %}
+                                    {{ tr('bylo', 'was') }}
+                                {% else %}
+                                    {{ tr('bude', 'will be') }}
+                                {% endif %}
+                            {% endif %}
+                            <em class="title">{{ event | event_link }}</em>
+                        </div>
+                        <span>
+                            {% if event.venue %}
+                                {{event.venue.name}}{% if event.venue.address %},
+                                    {{event.venue.short_address}}
+                                {% endif %}
+                            {% endif %}
+                        </span>
+                    </div>
                 </div>
-                <span>
-                    {% if event.venue %}
-                        {{event.venue.name}}{% if event.venue.address %},
-                            {{event.venue.short_address}}
-                        {% endif %}
-                    {% endif %}
-                </span>
-            </div>
             {% endfor %}
         </div>
     </div>


### PR DESCRIPTION
Ahoj, navrhuji dát eventy vedle sebe:

![pyvo events after](https://cloud.githubusercontent.com/assets/115487/23545469/b98fff82-fffb-11e6-9e94-14b7d7b4e439.png)

Předchozí stav:

![pyvo events before](https://cloud.githubusercontent.com/assets/115487/23545471/bd2b19b0-fffb-11e6-9e57-f197166087be.png)

Tohle je moje impulzivní úprava, nezkoumal jsem, jestli tuto změnu už někdo navrhoval nebo byla někde diskutována. Jestli nebude přijata, nevadí.

Kdyby těch eventů byl jiný počet, než tři, tak by se dal změnit počet sloupců, nebo ten přebývající třeba odsadit, aby byl uprostřed.