### PR TITLE
gitignore pyvocz-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /*.egg-info/
 __pycache__/
 /pyvocz/pyvo-data/
+pyvocz-env

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then install with:
 
 Alternatively, if you've cloned the repository, run this in your copy:
 
-    pip install -e.
+    pip install -e .
 
 (Nothing should depend on the pyvocz module, so it's not on PyPI.)
 


### PR DESCRIPTION
V readme se doporučuje udělat si venv:

    python3 -m venv pyvocz-env

Tak navrhuju to přidat do gitignore.

Taky jsem si dovolil přidat jednu mezeru :)