### PR TITLE
Main page: show next event if there are more future ones planned

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ install:
   - pip install pytest pytest-flask lxml requests cssselect
   - git clone --depth 1 https://github.com/pyvec/pyvo-data pyvocz/pyvo-data
 
-script: py.test
+script: py.test test_pyvocz
 
 sudo: false


### PR DESCRIPTION
This should fix https://github.com/pyvec/pyvo.cz/issues/86 for the home page.
The series page (https://pyvo.cz/ostrava-pyvo/) still shows the wrong event if several events are planned for the future.