### PR TITLE
 Series page: Handle several upcoming meetups

### DIFF
--- a/pyvocz/templates/series.html
+++ b/pyvocz/templates/series.html
@@ -19,15 +19,14 @@
         </div>
     </div>
 
-    {% if has_events %}
-        {% set event = series.events[0] %}
-
-        {% if event.venue %}
+    {% if featured_event %}
+        {% if featured_event.venue %}
             <div id="map" style="height: 350px"
-                data-src="{{ url_for('api_venue_geojson', venueslug=event.venue.slug) }}"
+                data-src="{{ url_for('api_venue_geojson',
+                                     venueslug=featured_event.venue.slug) }}"
                 data-zoom="14"
-                data-lat="{{event.venue.latitude}}"
-                data-lng="{{event.venue.longitude}}"
+                data-lat="{{featured_event.venue.latitude}}"
+                data-lng="{{featured_event.venue.longitude}}"
             >
             </div>
         {% endif %}
@@ -48,41 +47,19 @@
 
     {% if year==None %}
         <div id="featured-meetup">
-            {% if has_events %}
-                {% if event.date < today %}
+            {% if featured_event %}
+                {% if featured_event.date < today %}
                      <h2>{{ tr('Poslední sraz', 'Last Meetup') }}</h2>
-                {% elif event.date > today %}
+                {% elif featured_event.date > today %}
                      <h2>{{ tr('Nadcházející sraz', 'Next Meetup') }}</h2>
                 {% else %}
                      <h2>{{ tr('Dnešní sraz', "Today's Meetup") }}</h2>
                 {% endif %}
 
-                {{ event_entry(event, is_header_event=True, add_venue_notes=True) }}
+                {{ event_entry(featured_event, is_header_event=True,
+                               add_venue_notes=True) }}
             {% endif %}
         </div>
-
-        {% if series.recurrence_rule %}
-        <div id="future">
-            <h2>{{ tr('Budoucí termíny', 'Future dates') }}</h2>
-            <div>
-                {{ tr(series.recurrence_description_cs, series.recurrence_description_en) }}
-            </div>
-            <div>
-                {% if g.lang_code == 'cs' %}
-                    Předběžně to vypadá na následující termíny –
-                    některé se ale můžou posunout, např. kvůli svátkům:
-                {% else %}
-                    That means the following days are likely – but some
-                    might be rescheduled, for example to avoid holidays.
-                {% endif %}
-            </div>
-            <ul>
-                {% for occurence in series.next_occurrences(3) %}
-                    <li>{{ occurence | longdate }}</li>
-                {% endfor %}
-            </ul>
-        </div>
-        {% endif %}
 
         {% if organizer_info %}
         <div id="organizer-contacts">
@@ -113,7 +90,37 @@
         {% endif %}
     {% endif %}
 
-    {% if series.events|length > 1 %}
+        {% if series.recurrence_rule or future_events %}
+        <div id="future">
+            <h2>{{ tr('Budoucí termíny', 'Future dates') }}</h2>
+            {% if future_events %}
+                {% for event in future_events %}
+                    {{ event_entry(event, is_header_event=True, add_venue_notes=True) }}
+                {% endfor %}
+            {% endif %}
+            {% if series.recurrence_rule %}
+            <div>
+                {{ tr(series.recurrence_description_cs, series.recurrence_description_en) }}
+            </div>
+            <div>
+                {% if g.lang_code == 'cs' %}
+                    Předběžně to vypadá na následující termíny –
+                    některé se ale můžou posunout, např. kvůli svátkům:
+                {% else %}
+                    That means the following days are likely – but some
+                    might be rescheduled, for example to avoid holidays.
+                {% endif %}
+            </div>
+            <ul>
+                {% for occurence in series.next_occurrences(3) %}
+                    <li>{{ occurence | longdate }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+        {% endif %}
+
+    {% if past_events %}
     <div class="event-list">
         <h2>{{ tr('Historie srazů', 'Meetup History') }}</h2>
         {% macro pagination() %}
@@ -143,8 +150,8 @@
         {% endmacro %}
         {{ pagination() }}
         <ul>
-            {% if has_events %}
-                {% for event in series.events[1 if year==None else 0:] %}
+            {% if past_events %}
+                {% for event in past_events %}
                     <li>
                         {{ event_entry(event) }}
                     </li>

--- a/pyvocz/views.py
+++ b/pyvocz/views.py
@@ -176,6 +176,7 @@ def series(series_slug, year=None, all=None):
 
     today = datetime.date.today()
 
+    # List of years to show in the pagination
     # If there are no years with events, put the current year there at least
     all_years = years_with_events(series_slug) or [today.year]
     first_year, last_year = min(all_years), max(all_years)
@@ -187,9 +188,11 @@ def series(series_slug, year=None, all=None):
 
     if year is not None:
         if year > last_year:
-            year = None
-        elif year < first_year:
-            year = first_year
+            # Instead of showing a future year, redirect to the 'New' page
+            return redirect(url_for('series', series_slug=series_slug))
+        if year not in all_years:
+            # Otherwise, if there are no events in requested year, return 404.
+            abort(404)
 
     if all is not None:
         paginate_prev = {'year': first_year}
@@ -198,15 +201,17 @@ def series(series_slug, year=None, all=None):
         paginate_prev = {'year': None}
         paginate_next = {'year': last_year}
     else:
-        if year >= last_year:
-            paginate_prev = {'year': None}
+        past_years = [y for y in all_years if y < year]
+        if past_years:
+            paginate_next = {'year': max(past_years)}
         else:
-            paginate_prev = {'year': all_years[all_years.index(year) + 1]}
-
-        if year <= first_year:
             paginate_next = {'all': 'all'}
+
+        future_years = [y for y in all_years if y > year]
+        if future_years:
+            paginate_prev = {'year': min(future_years)}
         else:
-            paginate_next = {'year': all_years[all_years.index(year) - 1]}
+            paginate_prev = {'year': None}
 
     query = db.session.query(tables.Series)
     query = query.filter(tables.Series.slug == series_slug)

--- a/pyvocz/views.py
+++ b/pyvocz/views.py
@@ -248,9 +248,27 @@ def series(series_slug, year=None, all=None):
         except NoResultFound:
             abort(404)
 
+    # Split events between future and past
+    # (today's event, if any, is considered future)
+    past_events = [e for e in series.events if e.date < today]
+    future_events = [e for e in series.events if e.date >= today]
+
+    # Events are ordered closest first;
+    #  for future ones this means ascending order
+    future_events.reverse()
+
+    featured_event = None
+    if year is None:
+        # Pop the featured event -- closest future one, or latest past one
+        if future_events:
+            featured_event = future_events.pop(0)
+        elif past_events:
+            featured_event = past_events.pop(0)
 
     organizer_info = json.loads(series.organizer_info)
     return render_template('series.html', series=series, today=today, year=year,
+                           future_events=future_events, past_events=past_events,
+                           featured_event=featured_event,
                            organizer_info=organizer_info, all=all,
                            first_year=first_year, last_year=last_year,
                            all_years=all_years, paginate_prev=paginate_prev,


### PR DESCRIPTION
The site wasn't prepared for several events of a series scheduled in the future, see https://github.com/pyvec/pyvo.cz/issues/86. This fixes it for the series page, which should be the last area where this is a problem.

The first commit should make the series pagination a bit more robust; in particular it should remove the assumption that there are no "gap" years where a series had no meetups.