### PR TITLE
Update dependencies: lxml, pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ Flask-SQLAlchemy==2.2
 ics==0.3.1
 itsdangerous==0.24
 Jinja2==2.9.6
-lxml==3.8.0
+lxml==4.2.3
 Markdown==2.6.8
 MarkupSafe==1.0
 Pillow==5.0.0
 python-dateutil==2.6.1
 pyvodb==0.3.10
-PyYAML==3.12
+PyYAML==3.13
 qrcode==5.3
 six==1.10.0
 SQLAlchemy==1.1.12


### PR DESCRIPTION
The command `pip install -r requirements.txt` in a Python 3.7 venv has
failed on gcc errors before this update, now it works fine.