### PR TITLE
Podpora více různých akcí v jeden den

### DIFF
--- a/pyvocz/static/style.css
+++ b/pyvocz/static/style.css
@@ -481,6 +481,8 @@ div.map .map-city.future a { color: black; }
     color: #C2AE84;
     text-align: center;
     min-width: 2em;
+    max-width: 1.4em;
+    box-sizing: content-box;
 }
 
 .calendar table tr .nowork {
@@ -496,6 +498,15 @@ div.map .map-city.future a { color: black; }
     width: 1.3em;
     position: relative;
     top: 2px;
+}
+
+.calendar table td.multiple-events {
+    border: 1px solid #C2AE84;
+}
+
+.calendar table .multiple-events img {
+    width: 0.75em;
+    top: 0;
 }
 
 .export-links ul,

--- a/pyvocz/templates/_macros.html
+++ b/pyvocz/templates/_macros.html
@@ -40,18 +40,22 @@
                                 {% if day['day'] == today %}today{% endif %}
                                 {% if loop.index > 5 or (day['holiday']) %}nowork{% endif %}
                                 {% if day['events'] %}has-event{% endif %}
+                                {% if (day['events'] | length) > 1 %}
+                                    multiple-events
+                                {% endif %}
                                 "
                             >
                                 {% if day['events'] %}
-                                    {% set event = day['events'][0] %}
-                                    <a href="{{ url_for('event', series_slug=event.series.slug,
-                                                        date_slug=event.slug) }}">
-                                        <img src="{{ url_for('static', filename='coatofarms/'+event.series.home_city_slug+'.svg') }}"
-                                            width="20"
-                                            alt="{{day['day'] | shortday}} – {{ event.title }}"
-                                            title="{{day['day'] | shortday}} – {{ event.title }}"
-                                        >
-                                    </a>
+                                    {% for event in day['events'] %}
+                                        <a href="{{ url_for('event', series_slug=event.series.slug,
+                                                            date_slug=event.slug) }}">
+                                            <img src="{{ url_for('static', filename='coatofarms/'+event.series.home_city_slug+'.svg') }}"
+                                                width="20"
+                                                alt="{{day['day'] | shortday}} – {{ event.title }}"
+                                                title="{{day['day'] | shortday}} – {{ event.title }}"
+                                            >
+                                        </a>
+                                    {% endfor %}
                                 {% elif day['next_occurences'] %}
                                     {% set series = day['next_occurences'][0] %}
                                     <a href="{{ url_for('series', series_slug=series.slug,

--- a/pyvocz/templates/_macros.html
+++ b/pyvocz/templates/_macros.html
@@ -21,6 +21,48 @@
     {% endif %}
 {% endmacro %}
 
+{% macro _calendar_day(day, is_nowork, is_today) %}
+    {% if day['alien'] %}
+        <td {% if is_nowork %}class="nowork"{% endif %}>&nbsp;</td>
+    {% else %}
+        <td class="
+            {% if is_today %}today{% endif %}
+            {% if is_nowork or (day['holiday']) %}nowork{% endif %}
+            {% if day['events'] %}has-event{% endif %}
+            {% if (day['events'] | length) > 1 %}
+                multiple-events
+            {% endif %}
+            "
+        >
+            {% if day['events'] %}
+                {% for event in day['events'] %}
+                    <a href="{{ url_for('event', series_slug=event.series.slug,
+                                        date_slug=event.slug) }}">
+                        <img src="{{ url_for('static', filename='coatofarms/'+event.series.home_city_slug+'.svg') }}"
+                            width="20"
+                            alt="{{day['day'] | shortday}} – {{ event.title }}"
+                            title="{{day['day'] | shortday}} – {{ event.title }}"
+                        >
+                    </a>
+                {% endfor %}
+            {% elif day['next_occurences'] %}
+                {% set series = day['next_occurences'][0] %}
+                <a href="{{ url_for('series', series_slug=series.slug,
+                                    _anchor='future') }}">
+                    <img src="{{ url_for('static', filename='coatofarms/'+series.home_city_slug+'-gray.svg') }}"
+                        width="20"
+                        alt="{{day['day'] | shortday}} – {{ tr('možný termín pro', 'possible date for') }} {{ series.name }}"
+                        title="{{day['day'] | shortday}} – {{ tr('možný termín pro', 'possible date for') }} {{ series.name}}"
+                        style="opacity:0.2;"
+                    >
+                </a>
+            {% else %}
+                {{ day['day'].day }}
+            {% endif %}
+        </td>
+    {% endif %}
+{% endmacro %}
+
 {% macro calendar_month(year, month, weeks, today) %}
     <table>
         <caption>{{ month | monthname }}</caption>
@@ -33,45 +75,11 @@
             {% if (week[0]['day'].year, week[0]['day'].month) <= (year, month) %}
                 <tr>
                     {% for day in week %}
-                        {% if day['alien'] %}
-                            <td {% if loop.index > 5 %}class="nowork"{% endif %}>&nbsp;</td>
-                        {% else %}
-                            <td class="
-                                {% if day['day'] == today %}today{% endif %}
-                                {% if loop.index > 5 or (day['holiday']) %}nowork{% endif %}
-                                {% if day['events'] %}has-event{% endif %}
-                                {% if (day['events'] | length) > 1 %}
-                                    multiple-events
-                                {% endif %}
-                                "
-                            >
-                                {% if day['events'] %}
-                                    {% for event in day['events'] %}
-                                        <a href="{{ url_for('event', series_slug=event.series.slug,
-                                                            date_slug=event.slug) }}">
-                                            <img src="{{ url_for('static', filename='coatofarms/'+event.series.home_city_slug+'.svg') }}"
-                                                width="20"
-                                                alt="{{day['day'] | shortday}} – {{ event.title }}"
-                                                title="{{day['day'] | shortday}} – {{ event.title }}"
-                                            >
-                                        </a>
-                                    {% endfor %}
-                                {% elif day['next_occurences'] %}
-                                    {% set series = day['next_occurences'][0] %}
-                                    <a href="{{ url_for('series', series_slug=series.slug,
-                                                        _anchor='future') }}">
-                                        <img src="{{ url_for('static', filename='coatofarms/'+series.home_city_slug+'-gray.svg') }}"
-                                            width="20"
-                                            alt="{{day['day'] | shortday}} – {{ tr('možný termín pro', 'possible date for') }} {{ series.name }}"
-                                            title="{{day['day'] | shortday}} – {{ tr('možný termín pro', 'possible date for') }} {{ series.name}}"
-                                            style="opacity:0.2;"
-                                        >
-                                    </a>
-                                {% else %}
-                                    {{ day['day'].day }}
-                                {% endif %}
-                            </td>
-                        {% endif %}
+                        {{ _calendar_day(
+                            day,
+                            is_nowork=loop.index>5,
+                            is_today=day['day'] == today,
+                        ) }}
                     {% endfor %}
                 </tr>
             {% endif %}


### PR DESCRIPTION
#98: Liberecké Pyvo by se rádo konalo ve stejné termíny jako Brněnské nebo Ostravské Pyvo, ale nemůže, protože web umí v jeden den jen jedno Pyvo.

Napadá mě to vyřešit tak, že erby v kalendáři budou dva menší.
Od tří Pyv v jednom dni to tu tabulku dost rozhodí, ale to bych asi řešil až bude potřeba...