### PR TITLE
A bunch of small changes

### DIFF
--- a/pyvocz/templates/_base.html
+++ b/pyvocz/templates/_base.html
@@ -79,7 +79,7 @@
             {% else %}
                 <div>
                     Managed by <a href="http://pyvec.org">pyvec.org</a>, a non-profit organization.
-                    Send e-mails to <a href="mailto:info&#64;pyvec.org">info&#64;<!---->pyvec.org</a>, tweet to <a href="https://twitter.com/pyvec">@pyvec</a>.
+                    Send e-mails to <a href="mailto:info&#64;pyvec.org">info&#64;<!---->pyvec.org</a>, tweet to <a href="https://twitter.com/napyvo">@napyvo</a>.
                 </div>
                 <div>
                     Fork this site on <a href="http://github.com/pyvec/pyvo.cz">Github</a>. Pull requests welcome!

--- a/pyvocz/templates/event.html
+++ b/pyvocz/templates/event.html
@@ -110,9 +110,11 @@
                             </div>
                         {% endif %}
                         {% if talk.links %}
-                            <div class="talk-links-intro">
-                                {{ tr('Jinde na webu:', 'Elsewhere on the Web:') }}
-                            </div>
+                            {% if not talk.is_lightning %}
+                                <div class="talk-links-intro">
+                                    {{ tr('Jinde na webu:', 'Elsewhere on the Web:') }}
+                                </div>
+                            {% endif %}
                             <ul class="talk-links">
                                 {% for link in talk.links %}
                                     <li>

--- a/pyvocz/views.py
+++ b/pyvocz/views.py
@@ -411,6 +411,12 @@ def make_ics(query, url, *, recurrence_series=()):
             location=location,
             begin=event.start,
             uid='{}-{}@pyvo.cz'.format(event.series_slug, event.date),
+            url=url_for(
+                'event', series_slug=event.series.slug,
+                date_slug=event.slug,
+                _external=True,
+            ),
+            description=event.description,
         )
         cal_event.geo = '{}:{}'.format(geo_obj.latitude,
                                        geo_obj.longitude)

--- a/pyvocz/views.py
+++ b/pyvocz/views.py
@@ -11,7 +11,7 @@ import qrcode
 from sqlalchemy import func, or_, desc, extract
 from sqlalchemy.orm import joinedload, subqueryload, contains_eager
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
-from flask import request, Response, url_for, redirect
+from flask import request, Response, url_for, redirect, g
 from flask import render_template, jsonify
 from flask import current_app as app
 from werkzeug.exceptions import abort
@@ -427,9 +427,13 @@ def make_ics(query, url, *, recurrence_series=()):
         # but ics doesn't allow that yet:
         # https://github.com/C4ptainCrunch/ics.py/issues/14
         # Just show the 6 next events.
+        if g.lang_code == 'cs':
+            name_template = '({} – nepotvrzeno; tradiční termín srazu)'
+        else:
+            name_template = '({} – tentative date)'
         for occurence in series.next_occurrences(n=6, since=since):
             cal_event = ics.Event(
-                name='({}?)'.format(series.name),
+                name=name_template.format(series.name),
                 begin=occurence,
                 uid='{}-{}@pyvo.cz'.format(series.slug, occurence.date()),
             )


### PR DESCRIPTION
* event page: Remove "Elsewhere on the Web" heading for lightning talks
* iCal export: Make titles of tentative events more descriptive
* iCal export: Show next 6 months of tentative events
* iCal export: Add URLs and descriptions
* Fix Twitter handle -- @napyvo, not @pyvec
