### PR TITLE
[Liberec] Remove from featured series

### DIFF
--- a/pyvocz/views.py
+++ b/pyvocz/views.py
@@ -31,7 +31,6 @@ FEATURED_SERIES = (
     'ostrava-pyvo',
     'olomouc-pyvo',
     'plzen-pyvo',
-    'liberec-pyvo',
     'hradec-pyvo',
 )
 


### PR DESCRIPTION
Liberecké Pyvo je fakticky mrtvé, poslední sraz byl v květnu 2019. Aby
se uživatelé netěšili na sraz v letošním květnu, navrhuji odstranit
liberecké Pyvo z titulky.

Pokud se objeví někdo, kdo zorganizuje další setkání (já k tomu už
nebudu mít příležitost), není problém pokračovat dál.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>