### PR TITLE
Add link for adding the next event on GitHub

### DIFF
--- a/pyvocz/event_add.py
+++ b/pyvocz/event_add.py
@@ -1,0 +1,64 @@
+import textwrap
+import collections
+from urllib.parse import urlencode
+
+
+URL = 'https://github.com/pyvec/pyvo-data/new/master/series/{series}/events/f?{params}'
+
+
+def event_add_link(series):
+    """Generate a GitHub URL for adding a new event at the given date"""
+
+    city_slug = '...'
+    venue_slug = '...'
+    number = ''
+    next_date = '...'
+    next_datetime = '...'
+
+    if series.events:
+        last_event = series.events[-1]
+        city_slug = last_event.city.slug
+        if last_event.number:
+            number = f'number: {last_event.number + 1}'
+
+        c = collections.Counter(
+            e.venue.slug for e in series.events[-12:] if e.venue
+        )
+        most_common = [k for k, n in c.most_common(5)]
+        if most_common:
+            venue_slug = most_common[0]
+            if len(most_common) > 1:
+                venue_slug += '   # ' + ', '.join(most_common[1:]) + ' ?'
+
+    if series.recurrence_rule:
+        occurrences = list(series.next_occurrences(1))
+        if occurrences:
+            occurrence = occurrences[0]
+            next_datetime = occurrence.replace(tzinfo=None).isoformat(' ')
+            next_date = occurrence.date().isoformat()
+
+    params = {
+        'filename': f'{next_date}.yaml',
+        'value': textwrap.dedent(f"""\
+            name: {series.name}
+            city: {city_slug}
+            venue: {venue_slug}
+            start: {next_datetime}
+            # topic: ...
+            {number}
+            description: |
+                ...
+
+            talks:
+              - title: ...
+                description: |
+                    ...
+                lightning: false
+                speakers:
+                    - ...
+                    - ...
+        """),
+        'message': f'{series.home_city.name}: Add entry for {next_date}',
+    }
+
+    return URL.format(series=series.slug, params=urlencode(params), next_date=next_date)

--- a/pyvocz/templates/series.html
+++ b/pyvocz/templates/series.html
@@ -45,6 +45,15 @@
         </div>
     </div>
 
+    <div class="row">
+        <div class="event-add-link col-lg-12">
+            Organizátoři můžou na GitHubu
+            <a href="{{ event_add_link(series) }}">
+                přidat informace o dalším srazu</a
+            >.
+        </a>
+    </div>
+
     {% if year==None %}
         <div id="featured-meetup">
             {% if featured_event %}

--- a/pyvocz/views.py
+++ b/pyvocz/views.py
@@ -23,6 +23,7 @@ from pyvodb.calendar import get_calendar
 
 from . import filters
 from .db import db, db_reload
+from .event_add import event_add_link
 
 
 BACKCOMPAT_SERIES_ALIASES = {
@@ -269,14 +270,17 @@ def series(series_slug, year=None, all=None):
             featured_event = past_events.pop(0)
 
     organizer_info = json.loads(series.organizer_info)
-    return render_template('series.html', series=series, today=today,
-                           year=year, future_events=future_events,
-                           past_events=past_events,
-                           featured_event=featured_event,
-                           organizer_info=organizer_info, all=all,
-                           first_year=first_year, last_year=last_year,
-                           all_years=all_years, paginate_prev=paginate_prev,
-                           paginate_next=paginate_next, has_events=has_events)
+    return render_template(
+        'series.html', series=series, today=today,
+        year=year, future_events=future_events,
+        past_events=past_events,
+        featured_event=featured_event,
+        organizer_info=organizer_info, all=all,
+        first_year=first_year, last_year=last_year,
+        all_years=all_years, paginate_prev=paginate_prev,
+        paginate_next=paginate_next, has_events=has_events,
+        event_add_link=event_add_link,
+    )
 
 
 @route('/<series_slug>/<date_slug>/')


### PR DESCRIPTION
Very Minimal MVP for adding an entry for the next event

![image](https://user-images.githubusercontent.com/302922/89199490-e74f9680-d5ae-11ea-9ff8-f17841a444ca.png) → [long GitHub URL](https://github.com/pyvec/pyvo-data/new/master/series/brno-pyvo/events/f?filename=2020-08-27.yaml&value=name%3A+Brn%C4%9Bnsk%C3%A9+Pyvo%0Acity%3A+brno%0Avenue%3A+artbar+++%23+u-drevaka%2C+pivon%2C+luzanky+%3F%0Astart%3A+2020-08-27+19%3A00%3A00%0A%23+topic%3A+...%0A%0Adescription%3A+%7C%0A++++...%0A%0Atalks%3A%0A++-+title%3A+...%0A++++description%3A+%7C%0A++++++++...%0A++++lightning%3A+false%0A++++speakers%3A%0A++++++++-+...%0A++++++++-+...%0A&message=Brno%3A+Add+entry+for+2020-08-27)