### PR TITLE
Make Liberecké Pyvo look better

### DIFF
--- a/pyvocz/static/style.css
+++ b/pyvocz/static/style.css
@@ -10,6 +10,12 @@ h1, h2, h3, h4, h5, h6 {
     margin-top: 0;
 }
 
+h2, h3, h4, h5, h6 {
+    font-family: "Bree Serif", serif;
+    margin-top: .5em;
+    margin-bottom: .5em;
+}
+
 .container {
     background-color: #fdfeff;
     padding-top: 1em;

--- a/pyvocz/templates/series.html
+++ b/pyvocz/templates/series.html
@@ -51,7 +51,7 @@
             <a href="{{ event_add_link(series) }}">
                 přidat informace o dalším srazu</a
             >.
-        </a>
+        </div>
     </div>
 
     {% if year==None %}

--- a/pyvocz/templates/series.html
+++ b/pyvocz/templates/series.html
@@ -139,9 +139,17 @@
                         <a {% if year==None and all==None %}class="disabled"{% endif %}
                            href="{{ url_for('series', series_slug=series.slug, **paginate_prev) }}">&lt;</a>
                     </li>
-                    <li class="paginate-link {% if year==None and all==None %}current{% endif %}">
-                         <a href="{{ url_for('series', series_slug=series.slug, year=None) }}">{{ tr("Nové", "New") }}</a>
-                    </li>
+                    {% if new_history %}
+                        <li class="paginate-link {% if year==None and all==None %}current{% endif %}">
+                            <a href="{{ url_for('series', series_slug=series.slug, year=None) }}">
+                                {% if new_history %}
+                                    {{ tr("Nové", "New") }}
+                                {% else %}
+                                    {{ tr("Předchozí", "Previous") }}
+                                {% endif %}
+                            </a>
+                        </li>
+                    {% endif %}
                     {% for page in all_years|reverse %}
                         <li class="paginate-link {% if page==year %}current{% endif %}">
                              <a href="{{ url_for('series', series_slug=series.slug, year=page) }}">{{ page }}</a>


### PR DESCRIPTION
Show most recent past events on the series page, even if it's been a few years since they were held.

Plus: some HTML+CSS fixes.